### PR TITLE
[DP-1281] Add Pushdown Support for `Union` | `Intersect` | `Except` Set Operations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq"
+val sparkConnectorVersion = "4.1.8-aiq3"
 
 lazy val root = project
   .withId("singlestore-spark-connector")

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq2"
+val sparkConnectorVersion = "4.1.8-aiq3-yt10"
 
 lazy val root = project
   .withId("singlestore-spark-connector")

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq3"
+val sparkConnectorVersion = "4.1.8-aiq"
 
 lazy val root = project
   .withId("singlestore-spark-connector")

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq3-yt10"
+val sparkConnectorVersion = "4.1.8-aiq3"
 
 lazy val root = project
   .withId("singlestore-spark-connector")

--- a/src/main/scala/com/singlestore/spark/SQLGen.scala
+++ b/src/main/scala/com/singlestore/spark/SQLGen.scala
@@ -1,6 +1,7 @@
 package com.singlestore.spark
 
 import java.sql.{Date, Timestamp}
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._

--- a/src/main/scala/com/singlestore/spark/SQLGen.scala
+++ b/src/main/scala/com/singlestore/spark/SQLGen.scala
@@ -1,7 +1,6 @@
 package com.singlestore.spark
 
 import java.sql.{Date, Timestamp}
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -102,6 +101,8 @@ object SQLGen extends LazyLogging with DataSourceTelemetryHelpers {
     def on(c: Option[Joinable]): Statement = c.map(on).getOrElse(this)
 
     def where(c: Joinable): Statement = this + "\nWHERE" + c
+    def where(c: Joinable, isAntiJoin: Boolean): Statement =
+      this + s"\nWHERE${if (isAntiJoin) " NOT " else " "}EXISTS" + c
 
     def groupby(c: Joinable): Statement         = this + "\nGROUP BY" + c
     def groupby(c: Option[Joinable]): Statement = c.map(groupby).getOrElse(this)
@@ -503,6 +504,65 @@ object SQLGen extends LazyLogging with DataSourceTelemetryHelpers {
           .from(left)
           .join(right, joinType)
           .output(plan.output)
+
+      // Intersect and Except Operators are replaced with either semi-join
+      // and anti-join respectively in Spark or union, aggregate
+      case plan @ Join(relationOrSort(left),
+                       relationOrSort(right),
+                       joinType @ (LeftSemi | LeftAnti),
+                       Some(sortPredicates(condition)),
+                       _)
+        if getDMLConnProperties(left.reader.options, isOnExecutor = false) == getDMLConnProperties(
+          right.reader.options,
+          isOnExecutor = false) =>
+
+        val isAntiJoin = joinType match {
+          case LeftSemi => false
+          case LeftAnti => true
+          case _ =>
+            throw new IllegalArgumentException("Expected ONLY `LeftSemi` or `LeftAnti` joinType.")
+        }
+
+        newStatement(plan)
+          .selectAll()
+          .from(left)
+          .where(
+            block(
+              newStatement(plan)
+                .selectAll()
+                .from(right)
+                .where(condition)
+                .output(plan.output)
+            ),
+            isAntiJoin
+          )
+          .output(plan.output)
+
+    // not supporting Union by name OR allowMissingCols or non nullSafeEq or executeAsFullOuter
+    case plan @ Union(children,
+                      byName @ false,
+                      allowMissingCol @ false,
+                      nullSafeEq @ true,
+                      executeAsFullOuter @ false)
+        if children.collect { case relationOrSort(c) =>
+          getDMLConnProperties(c.reader.options, isOnExecutor = false)
+        }.toSet.size == 1 =>
+
+      newStatement(plan)
+        .selectAll()
+        .from(
+          block (
+            children.collect { case p @ relationOrSort(child) =>
+              block (
+                newStatement(p)
+                  .selectAll()
+                  .from(child)
+                  .output(p.output)
+              )
+            }.reduce(_ + "\nUNION ALL\n" + _)
+          )
+        )
+        .output(plan.output)
     }
   }
 

--- a/src/test/scala/com/singlestore/spark/SQLPushdownTestAiq.scala
+++ b/src/test/scala/com/singlestore/spark/SQLPushdownTestAiq.scala
@@ -1761,4 +1761,71 @@ class SQLPushdownTestAiq extends IntegrationSuiteBase with BeforeAndAfterEach wi
       }
     }
   }
+
+  describe("Set Operations") {
+    describe("Intersect") {
+      val f = "intersect"
+
+      it(s"${f.capitalize} works with full tables") {
+        testQuery("select * from users intersect select * from users_sample")
+      }
+      it(s"${f.capitalize} works with single columns from tables") {
+        testQuery("select id from users intersect select id from users_sample")
+      }
+      it(s"${f.capitalize} with partial pushdown because of udf") {
+        testQuery(
+          s"""
+             |select longIdentity(id) as $f from users
+             |intersect
+             |select longIdentity(id) as $f from users_sample
+             |""".stripMargin.linesIterator.map(_.trim).mkString(" "),
+          expectPartialPushdown = true,
+          expectSingleRead = true
+        )
+      }
+    }
+
+    describe("Except") {
+      val f = "except"
+
+      it(s"${f.capitalize} works with full tables") {
+        testQuery("select * from users except select * from users_sample")
+      }
+      it(s"${f.capitalize} works with single columns from tables") {
+        testQuery("select id from users except select id from users_sample")
+      }
+      it(s"${f.capitalize} with partial pushdown because of udf") {
+        testQuery(
+          s"""
+             |select longIdentity(id) as $f from users
+             |except
+             |select longIdentity(id) as $f from users_sample
+             |""".stripMargin.linesIterator.map(_.trim).mkString(" "),
+          expectPartialPushdown = true,
+          expectSingleRead = true
+        )
+      }
+    }
+
+    describe("Union") {
+      val f = "union"
+
+      it(s"${f.capitalize} works with full tables") {
+        testQuery("select * from users union all select * from users_sample")
+      }
+      it(s"${f.capitalize} works with single columns from tables") {
+        testQuery("select id from users union all select id from users_sample")
+      }
+      it(s"${f.capitalize} with partial pushdown because of udf") {
+        testQuery(
+          s"""
+             |select longIdentity(id) as $f from users
+             |union all
+             |select longIdentity(id) as $f from users_sample
+             |""".stripMargin.linesIterator.map(_.trim).mkString(" "),
+          expectPartialPushdown = true
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adding Pushdown Support for `Union` | `Intersect` | `Except` Set Operations to allow for Full Audience PushDown

## Test Notes

- `sbt "clean; compile"`

```
[success] Total time: 9 s, completed Nov 23, 2024, 2:43:54 AM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTest"`

```
[info] Run completed in 47 minutes, 59 seconds.
[info] Total number of tests run: 811
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 811, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 2887 s (48:07), completed Nov 23, 2024, 3:32:48 AM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTestAiq"`

```
[info] Run completed in 1 hour, 14 minutes, 50 seconds.
[info] Total number of tests run: 1693
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1693, failed 0, canceled 0, ignored 21, pending 0
[info] All tests passed.
[success] Total time: 4492 s (01:14:52), completed Nov 23, 2024, 4:48:11 AM
```

## Deploy Notes
- Merge to `master`
- `sbt "clean; compile; publish;"`
- Pickup in Flame