### PR TITLE
[DP-0000] Upgrade SingleStore JDBC Driver to Version 1.2.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq4"
+val sparkConnectorVersion = "4.1.8-aiq5"
 
 lazy val root = project
   .withId("singlestore-spark-connector")
@@ -71,7 +71,7 @@ lazy val root = project
       "org.apache.avro"        % "avro"                    % "1.11.4",
       "org.apache.commons"     % "commons-dbcp2"           % "2.7.0",
       "org.scala-lang.modules" %% "scala-java8-compat"     % "0.9.0",
-      "com.singlestore"        % "singlestore-jdbc-client" % "1.2.4",
+      "com.singlestore"        % "singlestore-jdbc-client" % "1.2.7",
       "io.spray"               %% "spray-json"             % "1.3.5",
       "io.netty"               % "netty-buffer"            % "4.1.70.Final",
       "org.apache.commons"     % "commons-dbcp2"           % "2.9.0",


### PR DESCRIPTION
Upgrading SingleStore JDBC Driver from Version `1.2.4` to version `1.2.7` 

## Test Notes

- `sbt "clean; compile"`

```
[success] Total time: 11 s, completed Apr 3, 2025, 6:15:41 PM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTest"`

```
[info] Run completed in 27 minutes, 43 seconds.
[info] Total number of tests run: 811
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 811, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 1664 s (27:44), completed Apr 3, 2025, 6:56:09 PM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTestAiq"`

```
[info] Run completed in 37 minutes, 49 seconds.
[info] Total number of tests run: 1693
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1693, failed 0, canceled 0, ignored 21, pending 0
[info] All tests passed.
[success] Total time: 2271 s (37:51), completed Apr 3, 2025, 7:34:54 PM
```

## Deploy Notes
- Merge to `master`
- `sbt "clean; compile; publish;"`
- Pickup in Flame