### PR TITLE
[DP-0000] Upgrade Flame Version for SingleStore Connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import xerial.sbt.Sonatype._
  */
 
 // update this version when picking up a new Flame release
-val aiqSparkVersion = "3-3-2-aiq120"
+val aiqSparkVersion = "3-3-2-aiq121"
 
 val sparkVersion       = aiqSparkVersion.substring(0, 5).replace("-", ".")
 val scalaVersionStr    = "2.12.15"
@@ -20,7 +20,7 @@ val jacksonDatabindVersion = sparkVersion match {
 }
 
 // increment this version when making a new release
-val sparkConnectorVersion = "4.1.8-aiq5"
+val sparkConnectorVersion = "4.1.8-aiq6"
 
 lazy val root = project
   .withId("singlestore-spark-connector")


### PR DESCRIPTION
Upgrading Flame Version

## Test Notes

- `sbt "clean; compile"`

```
[success] Total time: 8 s, completed Apr 3, 2025, 7:50:17 PM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTest"`

```
[info] Run completed in 15 minutes, 16 seconds.
[info] Total number of tests run: 811
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 811, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 923 s (15:23), completed Apr 3, 2025, 8:06:14 PM
```

- `sbt "testOnly com.singlestore.spark.SQLPushdownTestAiq"`

```
[info] Run completed in 21 minutes, 39 seconds.
[info] Total number of tests run: 1693
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1693, failed 0, canceled 0, ignored 21, pending 0
[info] All tests passed.
[success] Total time: 1301 s (21:41), completed Apr 3, 2025, 8:44:12 PM
```

## Deploy Notes
- Merge to `master`
- `sbt "clean; compile; publish;"`
- Pickup in Flame